### PR TITLE
add watchOptionsPoll argument allowing to set poll

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -21,6 +21,7 @@ const {
     chunkFilename,
     afterInitialBuildHook,
     afterRebuildHook,
+    watchOptionsPoll,
   },
 } = require('../utils/cliHandler');
 const { getReactScriptsVersion, isEjected } = require('../utils');
@@ -145,8 +146,11 @@ fs.emptyDir(paths.appBuild)
           inProgress = true;
         }
       }).apply(webpackCompiler);
-
-      webpackCompiler.watch({}, (err, stats) => {
+      
+      let watchOptions = {
+        poll: watchOptionsPoll || false;
+      };
+      webpackCompiler.watch(watchOptions, (err, stats) => {
         if (err) {
           return reject(err);
         }


### PR DESCRIPTION
This is required for watch to work in certain setup (Windows, Docker, etc) where inotify doesn't work.

See https://webpack.js.org/configuration/watch/#watchoptionspoll